### PR TITLE
AUTH-352: cleanup unused inputs, clarify naming

### DIFF
--- a/go_build_artifact/action.yml
+++ b/go_build_artifact/action.yml
@@ -1,13 +1,10 @@
-name: 'GO: Build and push docker'
-description: 'Builds golang image, builds docker, pushes to gcr.io'
+name: 'GO: Build artifact'
+description: 'Builds golang image'
 inputs:
   build-command:
     description: 'Command to build your service (i.e. make build)'
     required: false
     default: 'make artifact-local'
-  project:
-    description: 'GCP project'
-    required: true
   service:
     description: 'Service to build'
     required: true


### PR DESCRIPTION
Just removing an unused input, but also naming things for clarity.